### PR TITLE
Tweaked the script to put less load on the Blink servers and allow me to sync

### DIFF
--- a/blinkVideoDownloader.py
+++ b/blinkVideoDownloader.py
@@ -4,6 +4,12 @@ import requests
 import shutil
 import os
 import sys
+import json
+
+from datetime import datetime
+import pytz
+
+import os.path
 
 if len(sys.argv) != 3:
     print('usage: ' + sys.argv[0] + ' email password')
@@ -18,8 +24,8 @@ res = requests.post('https://rest.prod.immedia-semi.com/login', headers=headers,
 authToken = res.json()["authtoken"]["authtoken"]
 region = res.json()["region"]
 region = list(region.keys())[0]
-#print(region)
 
+print(region)
 print(authToken)
 
 headers = {
@@ -27,18 +33,31 @@ headers = {
     'TOKEN_AUTH': authToken,
 }
 
-pageNum = 0
+fileFormat = "%Y-%m-%d %H-%M-%S"
+pageNum = 1  # Page actually appear to start at one
 while True:
     pageNumUrl = 'https://rest-'+region+'.immedia-semi.com/api/v2/videos/page/' + str(pageNum)
-    print(pageNumUrl)
+    print("## Processing page - " + str(pageNum) + " ##")
     res = requests.get(pageNumUrl, headers=headers)
     videoListJson = res.json()
     if not videoListJson:
         break
     for videoJson in videoListJson:
+        # print(json.dumps(videoJson, indent=4, sort_keys=True))
         mp4Url = 'https://rest-'+region+'.immedia-semi.com' + videoJson["address"]
-        print(mp4Url)
-        res = requests.get(mp4Url, headers=headers, stream=True)
-        with open(os.path.basename(mp4Url)[10:], 'wb') as out_file:
-            shutil.copyfileobj(res.raw, out_file)
+        datetime_object = datetime.strptime(videoJson["created_at"], '%Y-%m-%dT%H:%M:%S+00:00')
+        utcmoment = datetime_object.replace(tzinfo=pytz.utc)
+        localDatetime = utcmoment.astimezone(pytz.timezone(videoJson["time_zone"]))
+        fileName = localDatetime.strftime(fileFormat) + " - " + videoJson["camera_name"] + " - " + videoJson["network_name"] + ".mp4"
+
+        if os.path.isfile(fileName):
+            print(" * Skipping " + fileName + " *")
+            # print("Already downloaded (diff : " + str((int(videoJson["size"])-os.path.getsize(fileName))) + " bytes)")
+        else:
+            # print("Downloading - " + mp4Url)
+            print("Saving - " + fileName)
+            res = requests.get(mp4Url, headers=headers, stream=True)
+            with open("tmp-download", 'wb') as out_file:
+                shutil.copyfileobj(res.raw, out_file)
+            os.rename("tmp-download", fileName)
     pageNum += 1


### PR DESCRIPTION
Creates filenames with the timezone appropriate to each video (as opposed to UTC all the time), along with a more readable name based on Network and Camera (I need this as I have multiple networks), it also skips files already present locally and tries to ensure files are fully downloaded before naming them.

I have tested this on a system with six cameras and two networks across two time-zones and it meets my needs well. I had toyed with the idea of creating a directory for each network, but most users won't care and it would make the script a little more complicated.